### PR TITLE
fix(downloadmapimage): fixed box x/y coordinate order for Leaflet layer-point conversion

### DIFF
--- a/src/NetCore/Web/Api/wwwroot/scripts/api/webgis.tools.js
+++ b/src/NetCore/Web/Api/wwwroot/scripts/api/webgis.tools.js
@@ -2053,8 +2053,8 @@ webgis.tools.boxEvent = function (map, e, box, crs) {
         this.world.Y = ll[1] * .5 + ur[1] * .5;
     }
 
-    var p1 = map.frameworkElement.latLngToLayerPoint([box[0], box[1]]);
-    var p2 = map.frameworkElement.latLngToLayerPoint([box[2], box[3]]);
+    var p1 = map.frameworkElement.latLngToLayerPoint([box[1], box[0]]);
+    var p2 = map.frameworkElement.latLngToLayerPoint([box[3], box[2]]);
     //console.log(p1, p2);
 
     this.toEventString = function (map, tool) {


### PR DESCRIPTION
## Summary
Fixes the pixel width/height calculation in map-download rectangle selection mode.

## Problem
As the documentation shows, box is defined as `[minX, minY, maxX, maxY]`
https://github.com/e-netze/webgis/blob/a0126cce3b23237ce09a6ba21756b079544654e1/src/NetCore/Mcp/webgis-api-mcp/Tools/WebGISApiTools.cs#L62
[Leaflet#LatLng](https://leafletjs.com/reference.html#latlng) expects `[lat, lng]` as shown in the [example](https://leafletjs.com/reference.html#latlng-example)
```js
map.panTo([50, 30]);
map.panTo({lat: 50, lng: 30});
```
with Latitude (_lat_) representing the North-South position (vertical=Y);
and Longitude (_lng_) represents the East-West position (horizontal=X).

So `[lat, lng]` means `[y, x]` while the current code
https://github.com/e-netze/webgis/blob/a0126cce3b23237ce09a6ba21756b079544654e1/src/NetCore/Web/Api/wwwroot/scripts/api/webgis.tools.js#L2056-L2057

with `[minX, minY, maxX, maxY]` hands over `[minX, minY]` and `[maxX, maxY]` instead of `[minY, minX]` and `[maxY, maxX]` which is fixed by
```js
var p1 = map.frameworkElement.latLngToLayerPoint([box[1], box[0]]);
var p2 = map.frameworkElement.latLngToLayerPoint([box[3], box[2]]);
```

## Change
Swap the array index order.
```
// Old: [minX, minY]
// New: [minY, minX] -> [box[1], box[0]]
```
```
// Old: [maxX, maxY]
// New: [maxY, maxX] -> [box[3], box[2]]
```

## Reproduce
1. Open `map-download -> select-rectangle`
2. Draw a square selection
3. Compare the result for the two diagonal directions:
   - descending `\`
   - ascending `/`

## Notes
This is a frontend-only issue and fix.
